### PR TITLE
docs: update Chinese README link to point to the correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scrcpy Mask
 
-[中文](./README.md)
+[中文](./README-zh.md)
 
 **Scrcpy Mask** is a cross-platform desktop client built with **Rust + Bevy + React**, designed for efficient control of Android devices.
 It provides an intuitive visual interface for configuring mouse and keyboard mappings, enabling multi-touch operations similar to Android emulators.


### PR DESCRIPTION
## What does this PR do?

Fixed incorrect link paths in the Chinese documentation.


## Related issues

None.
