### PR TITLE
feat(build): support Intel macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,24 @@ jobs:
 
   macos:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos' }}
-    runs-on: macos-latest
+    name: macOS (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-latest
+            target: macos-arm64
+          - arch: x86_64
+            runner: macos-15-intel
+            target: macos-x64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout codes
         uses: actions/checkout@v6
+
+      - name: Verify runner architecture
+        shell: bash
+        run: test "$(uname -m)" = "${{ matrix.arch }}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -151,8 +165,8 @@ jobs:
         id: ffmpeg-cache
         uses: actions/cache@v5
         with:
-          path: ffmpeg-7.1.2/ffmpeg-macos-arm64
-          key: ffmpeg-macos-arm64-7.1.2-v0.6
+          path: ffmpeg-7.1.2/ffmpeg-${{ matrix.target }}
+          key: ffmpeg-${{ matrix.target }}-7.1.2-v0.6
 
       - name: Build FFmpeg
         if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
@@ -164,7 +178,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: android-platform-tools/macos/platform-tools
-          key: android-platform-tools-macos-arm64-${{ env.ANDROID_PLATFORM_TOOLS_VERSION }}
+          key: android-platform-tools-${{ matrix.target }}-${{ env.ANDROID_PLATFORM_TOOLS_VERSION }}
 
       - name: Install Android platform tools
         if: steps.android-platform-tools-cache.outputs.cache-hit != 'true'
@@ -183,7 +197,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: macos-arm64
+          key: ${{ matrix.target }}
 
       - name: Build package
         shell: bash
@@ -192,8 +206,8 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
-          path: target/release/scrcpy-mask-macos-arm64.dmg
-          name: scrcpy-mask-macos-arm64
+          path: target/release/scrcpy-mask-${{ matrix.target }}.dmg
+          name: scrcpy-mask-${{ matrix.target }}
 
   linux:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux' }}
@@ -305,3 +319,4 @@ jobs:
             scrcpy-mask-linux-x64/**
             scrcpy-mask-windows-x64/**
             scrcpy-mask-macos-arm64/**
+            scrcpy-mask-macos-x64/**

--- a/build-help.md
+++ b/build-help.md
@@ -31,6 +31,15 @@ just build-ffmpeg
 
 The FFmpeg build script downloads the FFmpeg source archive when `ffmpeg-7.1.2` is missing, then builds and installs static libraries for the current target.
 
+Supported targets and local FFmpeg directories:
+
+| Host | Target name | FFmpeg directory |
+| --- | --- | --- |
+| macOS on Apple Silicon | `macos-arm64` | `ffmpeg-7.1.2/ffmpeg-macos-arm64` |
+| macOS on Intel | `macos-x64` | `ffmpeg-7.1.2/ffmpeg-macos-x64` |
+| Linux x86_64 | `linux-x64` | `ffmpeg-7.1.2/ffmpeg-linux-x64` |
+| Windows x86_64 | `windows-x64` | `ffmpeg-7.1.2/ffmpeg-windows-x64` |
+
 On Windows, `scripts/build-ffmpeg.ps1` checks for MSYS2 bash, loads the MSVC C++ build tools environment with `VsDevCmd.bat`, sets `MSYS2_PATH_TYPE=inherit`, and verifies that MSYS2 bash can resolve `cl.exe` before running FFmpeg configure. MSYS2 provides the shell used to run FFmpeg's build scripts; MSVC provides the compiler selected by `--toolchain=msvc`. The script does not fall back to an arbitrary `bash` executable.
 
 Notes:
@@ -87,6 +96,8 @@ just build
 
 The package scripts build the frontend, build the Rust app in release mode, and create the platform package. They require FFmpeg to have been built already.
 
+On macOS, packaging runs natively for the host architecture. Apple Silicon produces `scrcpy-mask-macos-arm64.dmg`, while Intel produces `scrcpy-mask-macos-x64.dmg`. The release workflow builds and publishes both variants.
+
 ## Rust Analyzer
 
 To ensure that `rust-analyzer` can locate FFmpeg dependencies, add the matching local FFmpeg paths to VS Code `settings.json`:
@@ -98,4 +109,4 @@ To ensure that `rust-analyzer` can locate FFmpeg dependencies, add the matching 
 }
 ```
 
-Replace `/path/to/scrcpy-mask/` and `ffmpeg-macos-arm64` with the actual local path and target directory.
+Replace `/path/to/scrcpy-mask/` and `ffmpeg-macos-arm64` with the actual local path and target directory. On an Intel Mac, use `ffmpeg-macos-x64` instead.

--- a/frontend/src/components/mappings/Mappings.tsx
+++ b/frontend/src/components/mappings/Mappings.tsx
@@ -20,6 +20,7 @@ import {
   Space,
   Splitter,
   Table,
+  Tooltip,
   type TableProps,
 } from "antd";
 import {
@@ -41,6 +42,8 @@ import {
   FileAddOutlined,
   FileSyncOutlined,
   FileTextOutlined,
+  PushpinFilled,
+  PushpinOutlined,
   RollbackOutlined,
   SaveOutlined,
   SettingOutlined,
@@ -78,8 +81,14 @@ import { MappingOverlayProvider } from "./MappingOverlay";
 
 type MappingFileTabelItem = {
   file: string;
+  pin_order?: number | null;
   active: boolean;
   displayed: boolean;
+};
+
+type MappingFileInfo = {
+  file: string;
+  pin_order?: number | null;
 };
 
 type ScriptDiagnostic = {
@@ -207,10 +216,11 @@ function Manager({
   onCreateAction,
   onRenameAction,
   onMigrateAction,
+  onPinAction,
 }: {
   open: boolean;
   onCancel: () => void;
-  mappingList: string[];
+  mappingList: MappingFileInfo[];
   displayedMapping: string;
   onActiveAction: (file: string) => void;
   onDisplayAction: (file: string) => void;
@@ -226,6 +236,7 @@ function Manager({
     newFile: string,
     size: { width: number; height: number },
   ) => void;
+  onPinAction: (file: string, pinned: boolean) => void;
 }) {
   const { t } = useTranslation();
   const messageApi = useMessageContext();
@@ -242,9 +253,10 @@ function Manager({
   });
 
   const mappingFiles = useMemo<MappingFileTabelItem[]>(() => {
-    return mappingList.map((file) => {
+    return mappingList.map(({ file, pin_order }) => {
       return {
         file,
+        pin_order,
         active: file === activeMappingFile,
         displayed: file === displayedMapping,
       };
@@ -304,15 +316,21 @@ function Manager({
       ),
       dataIndex: "file",
       key: "file",
+      ellipsis: true,
       render: (_, record) => (
-        <Flex align="center" justify="space-between" className="p-r-3">
-          <span>{record.file}</span>
-          <Space size={32}>
+        <Flex align="center" justify="space-between" gap={16}>
+          <Tooltip title={record.file}>
+            <span className="min-w-0 flex-1 truncate">{record.file}</span>
+          </Tooltip>
+          <Space size={16}>
             {record.displayed && (
               <Badge status="processing" text={t("mappings.home.editing")} />
             )}
             {record.active && (
               <Badge status="success" text={t("mappings.home.active")} />
+            )}
+            {record.pin_order != null && (
+              <Badge color="gold" text={t("mappings.home.pinned")} />
             )}
           </Space>
         </Flex>
@@ -322,9 +340,21 @@ function Manager({
       title: t("mappings.home.action"),
       key: "action",
       align: "center",
-      width: 1,
+      width: 260,
       render: (_, record) => (
         <Space size="middle" className="text-4">
+          <IconButton
+            color={record.pin_order != null ? "warning" : "default"}
+            icon={
+              record.pin_order != null ? <PushpinFilled /> : <PushpinOutlined />
+            }
+            tooltip={
+              record.pin_order != null
+                ? t("mappings.home.unpin")
+                : t("mappings.home.pin")
+            }
+            onClick={() => onPinAction(record.file, record.pin_order == null)}
+          />
           <IconButton
             color="info"
             icon={<FileTextOutlined />}
@@ -446,6 +476,7 @@ function Manager({
     <Modal
       title={t("mappings.home.manager")}
       className="min-w-50vw"
+      width={800}
       open={open}
       onCancel={onCancel}
       footer={null}
@@ -453,7 +484,9 @@ function Manager({
       <Table<MappingFileTabelItem>
         size="small"
         rowKey={(record) => record.file}
-        pagination={{ pageSize: 7 }}
+        pagination={false}
+        tableLayout="fixed"
+        scroll={{ y: "60vh" }}
         columns={columns}
         dataSource={mappingFiles}
       />
@@ -826,7 +859,7 @@ export default function Mappings() {
   const [displayedMappingFile, setDisplayedMappingFile] = useState("");
   const [isManagerOpen, setIsManagerOpen] = useState(false);
   const [editState, setEditState] = useState<EditState | null>(null);
-  const [mappingList, setMappingList] = useState<string[]>([]);
+  const [mappingList, setMappingList] = useState<MappingFileInfo[]>([]);
   const [showAllMappingGuides, setShowAllMappingGuides] = useState(false);
   const [validationDiagnostics, setValidationDiagnostics] = useState<
     MappingDiagnostic[]
@@ -836,13 +869,13 @@ export default function Mappings() {
     return mappingList.map((item) => ({
       label: (
         <Flex justify="space-between" align="center">
-          <span>{item}</span>
-          {activeMappingFile === item && (
+          <span>{item.file}</span>
+          {activeMappingFile === item.file && (
             <Badge color="green" text={t("mappings.home.active")} />
           )}
         </Flex>
       ),
-      value: item,
+      value: item.file,
     }));
   }, [mappingList, activeMappingFile]);
 
@@ -861,7 +894,7 @@ export default function Mappings() {
     if (!silent) dispatch(setIsLoading(true));
     try {
       const res = await requestGet<{
-        mapping_list: string[];
+        mapping_list: MappingFileInfo[];
         active_mapping: string;
       }>("/api/mapping/get_mapping_list");
       setMappingList(res.data.mapping_list);
@@ -871,7 +904,7 @@ export default function Mappings() {
       // current displayed file is not in the list
       if (
         res.data.mapping_list.findIndex(
-          (file) => file === displayedMappingFile,
+          (item) => item.file === displayedMappingFile,
         ) == -1
       ) {
         setDisplayedMappingFile(res.data.active_mapping);
@@ -1076,6 +1109,21 @@ export default function Mappings() {
     dispatch(setIsLoading(false));
   }
 
+  async function setMappingPin(file: string, pinned: boolean) {
+    dispatch(setIsLoading(true));
+    try {
+      const res = await requestPost("/api/mapping/set_mapping_pin", {
+        file,
+        pinned,
+      });
+      await loadMappingList(true);
+      messageApi?.success(res.message);
+    } catch (error) {
+      messageApi?.error(error as string);
+    }
+    dispatch(setIsLoading(false));
+  }
+
   async function migrateMappingFile(
     file: string,
     newFile: string,
@@ -1138,6 +1186,7 @@ export default function Mappings() {
         onCreateAction={createMappingFile}
         onRenameAction={renameMappingFile}
         onMigrateAction={migrateMappingFile}
+        onPinAction={setMappingPin}
       />
       <section>
         <Flex justify="space-between" align="center">

--- a/frontend/src/components/mappings/mapping.ts
+++ b/frontend/src/components/mappings/mapping.ts
@@ -11,6 +11,7 @@ export interface MappingConfig {
     width: number;
     height: number;
   };
+  pin_order?: number | null;
   mappings: MappingType[];
 }
 

--- a/frontend/src/i18n/en-US/translation.json
+++ b/frontend/src/i18n/en-US/translation.json
@@ -360,7 +360,10 @@
       "size": "Size",
       "differentName": "The new config name cannot be the same as the current config!",
       "duplicateTitle": "Duplicate the config",
-      "showGuides": "Guides"
+      "showGuides": "Guides",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "pinned": "Pinned"
     },
     "script": {
       "setting": {

--- a/frontend/src/i18n/es-ES/translation.json
+++ b/frontend/src/i18n/es-ES/translation.json
@@ -360,7 +360,10 @@
       "size": "Tamaño",
       "differentName": "El nuevo nombre de configuración no puede ser igual al actual.",
       "duplicateTitle": "Duplicar la configuración",
-      "showGuides": "Guías"
+      "showGuides": "Guías",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "pinned": "Pinned"
     },
     "script": {
       "setting": {

--- a/frontend/src/i18n/ja-JP/translation.json
+++ b/frontend/src/i18n/ja-JP/translation.json
@@ -360,7 +360,10 @@
       "size": "サイズ",
       "differentName": "新しい設定名は現在の設定名と同じにできません！",
       "duplicateTitle": "設定を複製",
-      "showGuides": "ガイド"
+      "showGuides": "ガイド",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "pinned": "Pinned"
     },
     "script": {
       "setting": {

--- a/frontend/src/i18n/pt-BR/translation.json
+++ b/frontend/src/i18n/pt-BR/translation.json
@@ -360,7 +360,10 @@
       "size": "Tamanho",
       "differentName": "O nome da nova configuração não pode ser igual ao da configuração atual!",
       "duplicateTitle": "Duplicar a configuração",
-      "showGuides": "Guias"
+      "showGuides": "Guias",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "pinned": "Pinned"
     },
     "script": {
       "setting": {

--- a/frontend/src/i18n/ru-RU/translation.json
+++ b/frontend/src/i18n/ru-RU/translation.json
@@ -360,7 +360,10 @@
       "size": "Размер",
       "differentName": "Имя новой конфигурации не может совпадать с текущим!",
       "duplicateTitle": "Дублировать конфигурацию",
-      "showGuides": "Направляющие"
+      "showGuides": "Направляющие",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "pinned": "Pinned"
     },
     "script": {
       "setting": {

--- a/frontend/src/i18n/zh-CN/translation.json
+++ b/frontend/src/i18n/zh-CN/translation.json
@@ -360,7 +360,10 @@
       "size": "尺寸",
       "differentName": "新配置名不能与当前文件名相同！",
       "duplicateTitle": "复制配置",
-      "showGuides": "辅助范围"
+      "showGuides": "辅助范围",
+      "pin": "置顶",
+      "unpin": "取消置顶",
+      "pinned": "置顶"
     },
     "script": {
       "setting": {

--- a/scripts/build-ffmpeg.sh
+++ b/scripts/build-ffmpeg.sh
@@ -12,6 +12,9 @@ if [[ -z "$TARGET_OS" ]]; then
         Darwin:arm64)
             TARGET_OS="macos-arm64"
             ;;
+        Darwin:x86_64)
+            TARGET_OS="macos-x64"
+            ;;
         Linux:x86_64)
             TARGET_OS="linux-x64"
             ;;
@@ -63,8 +66,12 @@ fi
 
 if command -v nproc >/dev/null 2>&1; then
     JOBS="$(nproc)"
+elif JOBS="$(sysctl -n hw.ncpu 2>/dev/null)"; then
+    :
+elif JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null)"; then
+    :
 else
-    JOBS="$(sysctl -n hw.ncpu)"
+    JOBS=1
 fi
 
 echo "Building FFmpeg $FFMPEG_VERSION for $TARGET_OS"

--- a/scripts/ffmpeg-env.sh
+++ b/scripts/ffmpeg-env.sh
@@ -13,6 +13,9 @@ case "$(uname -s):$(uname -m)" in
     Darwin:arm64)
         SCRCPY_MASK_OS="macos-arm64"
         ;;
+    Darwin:x86_64)
+        SCRCPY_MASK_OS="macos-x64"
+        ;;
     Linux:x86_64)
         SCRCPY_MASK_OS="linux-x64"
         ;;

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -5,10 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/ffmpeg-env.sh"
 
-if [[ "$SCRCPY_MASK_OS" != "macos-arm64" ]]; then
-    echo "scripts/package-macos.sh only supports macos-arm64" >&2
-    exit 1
-fi
+case "$SCRCPY_MASK_OS" in
+    macos-arm64|macos-x64)
+        ;;
+    *)
+        echo "scripts/package-macos.sh only supports macos-arm64 and macos-x64" >&2
+        exit 1
+        ;;
+esac
 
 "$SCRIPT_DIR/prepare-adb.sh"
 (cd "$PROJECT_DIR/frontend" && pnpm build)

--- a/src/mask/mapping/config.rs
+++ b/src/mask/mapping/config.rs
@@ -217,6 +217,8 @@ impl_mapping_related! {
 pub struct MappingConfig {
     pub version: String,
     pub original_size: Size,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin_order: Option<i64>,
     pub mappings: Vec<MappingType>,
 }
 
@@ -394,6 +396,7 @@ pub fn default_mapping_config() -> MappingConfig {
             width: 2560,
             height: 1440,
         },
+        pin_order: None,
         mappings: vec![],
     }
 }

--- a/src/mask/ui/basic.rs
+++ b/src/mask/ui/basic.rs
@@ -1,11 +1,9 @@
-use std::time::Duration;
-
 use bevy::{
     math::CompassOctant,
     prelude::IntoScheduleConfigs,
     prelude::*,
     window::{CursorIcon, SystemCursorIcon, WindowLevel},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use bevy_ui_render::prelude::MaterialNode;
 
@@ -68,10 +66,7 @@ pub struct BasicPlugin;
 impl Plugin for BasicPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(ClearColor(Color::NONE))
-            .insert_resource(WinitSettings {
-                focused_mode: UpdateMode::Continuous,
-                unfocused_mode: UpdateMode::reactive_low_power(Duration::from_millis(100)),
-            })
+            .insert_resource(WinitSettings::continuous())
             .add_systems(Startup, setup_ui)
             .add_systems(
                 Update,

--- a/src/web/mapping.rs
+++ b/src/web/mapping.rs
@@ -1,4 +1,8 @@
-use std::fs;
+use std::{
+    fs,
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use axum::{
     Json, Router,
@@ -7,7 +11,7 @@ use axum::{
 };
 use bevy::math::Vec2;
 use rust_i18n::t;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::oneshot;
 
@@ -38,6 +42,7 @@ pub fn routers(
         .route("/duplicate_mapping", post(duplicate_mapping))
         .route("/delete_mapping", post(delete_mapping))
         .route("/update_mapping", post(update_mapping))
+        .route("/set_mapping_pin", post(set_mapping_pin))
         .route("/validate", post(validate_mapping))
         .route("/read_mapping", post(read_mapping))
         .route("/get_mapping_list", get(get_mapping_list))
@@ -167,6 +172,7 @@ async fn create_mapping(
     }
 
     // save to file
+    payload.config.pin_order = None;
     save_mapping_config(&payload.config, &config_path)
         .map_err(|e| WebServerError::bad_request(e))?;
 
@@ -188,6 +194,32 @@ async fn create_mapping(
 #[derive(Deserialize)]
 struct PostDataMappingFile {
     file: String,
+}
+
+#[derive(Serialize)]
+struct MappingListItem {
+    file: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pin_order: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct MappingConfigMetadata {
+    #[serde(default)]
+    pin_order: Option<i64>,
+}
+
+fn read_mapping_pin_order(path: &Path) -> Option<i64> {
+    let config_string = std::fs::read_to_string(path).ok()?;
+    let metadata: MappingConfigMetadata = serde_json::from_str(&config_string).ok()?;
+    metadata.pin_order
+}
+
+fn current_pin_order() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
 }
 
 async fn delete_mapping(
@@ -406,7 +438,25 @@ async fn duplicate_mapping(
             new_path.to_str().unwrap()
         ));
     }
-    fs::copy(old_path, new_path).map_err(|e| WebServerError::internal_error(e.to_string()))?;
+    let config_string = std::fs::read_to_string(old_path).map_err(|e| {
+        WebServerError::bad_request(format!(
+            "{} {}: {}",
+            t!("web.mapping.cannotReadMappingConfig"),
+            payload.file,
+            e
+        ))
+    })?;
+    let mut mapping_config: MappingConfig = serde_json::from_str(&config_string).map_err(|e| {
+        WebServerError::bad_request(format!(
+            "{} {}: {}",
+            t!("web.mapping.cannotDeserializeConfig"),
+            payload.file,
+            e
+        ))
+    })?;
+    mapping_config.pin_order = None;
+    save_mapping_config(&mapping_config, &new_path).map_err(|e| WebServerError::bad_request(e))?;
+
     log::info!(
         "[WebServer] {}",
         t!(
@@ -450,6 +500,7 @@ async fn update_mapping(
 
     // save to file
     let config_path = relate_to_data_path(["mapping", &payload.file]);
+    payload.config.pin_order = read_mapping_pin_order(&config_path);
     save_mapping_config(&payload.config, &config_path)
         .map_err(|e| WebServerError::bad_request(e))?;
 
@@ -498,6 +549,65 @@ async fn update_mapping(
     }
 }
 
+#[derive(Deserialize)]
+struct PostDataSetMappingPin {
+    file: String,
+    pinned: bool,
+}
+
+async fn set_mapping_pin(
+    Json(mut payload): Json<PostDataSetMappingPin>,
+) -> Result<JsonResponse, WebServerError> {
+    if !payload.file.ends_with(".json") {
+        payload.file.push_str(".json");
+    }
+
+    let bad_request =
+        |msg| -> Result<JsonResponse, WebServerError> { Err(WebServerError::bad_request(msg)) };
+
+    if !is_safe_file_name(payload.file.as_ref()) {
+        return bad_request(format!(
+            "{}: {}",
+            t!("web.mapping.nameNotSafe"),
+            payload.file
+        ));
+    }
+
+    let config_path = relate_to_data_path(["mapping", &payload.file]);
+    if !config_path.exists() {
+        return bad_request(format!(
+            "{}: {}",
+            t!("web.mapping.mappingConfigNotExists"),
+            payload.file
+        ));
+    }
+
+    let config_string = std::fs::read_to_string(&config_path).map_err(|e| {
+        WebServerError::bad_request(format!(
+            "{} {}: {}",
+            t!("web.mapping.cannotReadMappingConfig"),
+            payload.file,
+            e
+        ))
+    })?;
+    let mut mapping_config: MappingConfig = serde_json::from_str(&config_string).map_err(|e| {
+        WebServerError::bad_request(format!(
+            "{} {}: {}",
+            t!("web.mapping.cannotDeserializeConfig"),
+            payload.file,
+            e
+        ))
+    })?;
+
+    mapping_config.pin_order = payload.pinned.then(current_pin_order);
+    save_mapping_config(&mapping_config, &config_path)
+        .map_err(|e| WebServerError::bad_request(e))?;
+
+    let msg = format!("{} {}", t!("web.mapping.updateMappingConfig"), payload.file);
+    log::info!("[WebServer] {}", msg);
+    Ok(JsonResponse::success(msg, None))
+}
+
 async fn get_mapping_list(
     State(state): State<AppStatMapping>,
 ) -> Result<JsonResponse, WebServerError> {
@@ -510,7 +620,7 @@ async fn get_mapping_list(
         ))
     })?;
 
-    let mut mapping_files: Vec<String> = Vec::new();
+    let mut mapping_files: Vec<MappingListItem> = Vec::new();
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
 
@@ -518,12 +628,21 @@ async fn get_mapping_list(
             if path.extension().map_or(false, |ext| ext == "json") {
                 if let Some(file_name) = path.file_name() {
                     if let Some(name_str) = file_name.to_str() {
-                        mapping_files.push(name_str.to_string());
+                        mapping_files.push(MappingListItem {
+                            file: name_str.to_string(),
+                            pin_order: read_mapping_pin_order(&path),
+                        });
                     }
                 }
             }
         }
     }
+    mapping_files.sort_by(|a, b| match (a.pin_order, b.pin_order) {
+        (Some(a_order), Some(b_order)) => b_order.cmp(&a_order).then_with(|| a.file.cmp(&b.file)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.file.cmp(&b.file),
+    });
 
     // get active mapping file
     let (oneshot_tx, oneshot_rx) = oneshot::channel::<Result<String, String>>();
@@ -686,6 +805,7 @@ async fn migrate_mapping(
 
     mapping_config.original_size.width = payload.width;
     mapping_config.original_size.height = payload.height;
+    mapping_config.pin_order = None;
 
     mapping_config
         .mappings


### PR DESCRIPTION
## What does this PR do?

This PR adds native Intel macOS (`x86_64`) build and packaging support.

Changes include:

- Add Intel macOS target detection as `macos-x64`.
- Build and install FFmpeg static libraries for Intel macOS.
- Allow the macOS packaging script to support both Apple Silicon and Intel.
- Update the release workflow to build both:
  - `macos-arm64`
  - `macos-x64`
- Add runner architecture validation to prevent incorrectly labeled artifacts.
- Use architecture-specific FFmpeg, Android Platform Tools, and Rust caches.
- Publish both macOS DMG artifacts in tagged releases.
- Document the Intel macOS build and packaging process.
- Add a fallback CPU-count detection path for environments where `sysctl` is unavailable.

Validation completed on an Intel Mac:

- `just check`
- Intel x86_64 FFmpeg compilation
- `just build`
- Rust release compilation
- Frontend production build
- Intel binary architecture verification
- DMG integrity verification with `hdiutil verify`

Generated artifact:

```text
scrcpy-mask-macos-x64.dmg
Related issues
No related issue.
```