### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -57,4 +57,4 @@ Scrcpy Mask 基于其优秀架构，针对鼠标与键盘控制进行了进一�
 如果你对本项目感兴趣，欢迎提交 PR 或 Issue。
 由于个人时间和精力有限，可能无法及时处理所有反馈，敬请谅解。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AkiChase/scrcpy-mask&type=Date)](https://star-history.com/#AkiChase/scrcpy-mask&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AkiChase/scrcpy-mask&type=Date)](https://star-history.dera.page/#AkiChase/scrcpy-mask&Date)

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ The [build-help](./build-help.md) provides a brief description of how to run and
 If you’re interested in this project, feel free to submit a **PR** or open an **Issue**.
 Due to limited personal time and resources, I may not be able to respond to all feedback promptly — thank you for your understanding.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AkiChase/scrcpy-mask\&type=Date)](https://star-history.com/#AkiChase/scrcpy-mask&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AkiChase/scrcpy-mask\&type=Date)](https://star-history.dera.page/#AkiChase/scrcpy-mask&Date)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because the upstream service relies on the GitHub stargazer API, which now restricts unauthenticated access. This change points the chart to a working alternative that uses a different data source and requires no API token. The English and Chinese READMEs have both been updated.